### PR TITLE
fix: file format detect YAML before XML

### DIFF
--- a/lib/variableSubstitution.js
+++ b/lib/variableSubstitution.js
@@ -64,6 +64,20 @@ class VariableSubstitution {
                     }
                     isSubstitutionApplied = isJsonSubstitutionApplied || isSubstitutionApplied;
                 }
+                else if (this.isYaml(file, fileContent)) {
+                    console.log("Applying variable substitution on YAML file: " + file);
+                    let jsonSubsitution = new jsonVariableSubstitutionUtility_1.JsonSubstitution();
+                    let yamlObject = this.fileContentCache.get(file);
+                    let isYamlSubstitutionApplied = jsonSubsitution.substituteJsonVariable(yamlObject, envVariableUtility_1.EnvTreeUtility.getEnvVarTree());
+                    if (isYamlSubstitutionApplied) {
+                        fs.writeFileSync(file, (fileEncodeType.withBOM ? '\uFEFF' : '') + yaml.safeDump(yamlObject), { encoding: fileEncodeType.encoding });
+                        console.log(`Successfully updated config file: ${file}`);
+                    }
+                    else {
+                        console.log('Skipped updating file: ' + file);
+                    }
+                    isSubstitutionApplied = isYamlSubstitutionApplied || isSubstitutionApplied;
+                }
                 else if (this.isXml(file, fileContent)) {
                     console.log("Applying variable substitution on XML file: " + file);
                     let xmlDomUtilityInstance = this.fileContentCache.get(file);
@@ -84,20 +98,6 @@ class VariableSubstitution {
                         console.log('Skipped updating file: ' + file);
                     }
                     isSubstitutionApplied = isXmlSubstitutionApplied || isSubstitutionApplied;
-                }
-                else if (this.isYaml(file, fileContent)) {
-                    console.log("Applying variable substitution on YAML file: " + file);
-                    let jsonSubsitution = new jsonVariableSubstitutionUtility_1.JsonSubstitution();
-                    let yamlObject = this.fileContentCache.get(file);
-                    let isYamlSubstitutionApplied = jsonSubsitution.substituteJsonVariable(yamlObject, envVariableUtility_1.EnvTreeUtility.getEnvVarTree());
-                    if (isYamlSubstitutionApplied) {
-                        fs.writeFileSync(file, (fileEncodeType.withBOM ? '\uFEFF' : '') + yaml.safeDump(yamlObject), { encoding: fileEncodeType.encoding });
-                        console.log(`Successfully updated config file: ${file}`);
-                    }
-                    else {
-                        console.log('Skipped updating file: ' + file);
-                    }
-                    isSubstitutionApplied = isYamlSubstitutionApplied || isSubstitutionApplied;
                 }
                 else {
                     throw new Error("Could not parse file: " + file + "\n" + this.parseException);


### PR DESCRIPTION
Simply switched the priority of YAML and XML detection, detect YAML before XML to fix #26 

Testable action: [`toshichi/variable-substitution@v1.01` ](https://github.com/toshichi/variable-substitution/releases/tag/v1.01)
